### PR TITLE
Improve Arbotix-pro talking to Odroid and RPI2

### DIFF
--- a/Framework/include/CM730.h
+++ b/Framework/include/CM730.h
@@ -41,6 +41,7 @@ namespace Robot
 		virtual void ClearPort() = 0;
 		virtual int WritePort(unsigned char* packet, int numPacket) = 0;
 		virtual int ReadPort(unsigned char* packet, int numPacket) = 0;
+        virtual void FlushPort() = 0;
 
 		// Using semaphore
 		virtual void LowPriorityWait() = 0;

--- a/Framework/src/CM730.cpp
+++ b/Framework/src/CM730.cpp
@@ -148,7 +148,7 @@ int CM730::TxRxPacket(unsigned char *txpacket, unsigned char *rxpacket, int prio
 					to_length = txpacket[PARAMETER+1] + 6;
 				else
 					to_length = 6;
-
+                m_Platform->FlushPort();
 				m_Platform->SetPacketTimeout(length);
 
 				int get_length = 0;

--- a/Linux/build/LinuxCM730.cpp
+++ b/Linux/build/LinuxCM730.cpp
@@ -142,6 +142,12 @@ void LinuxCM730::ClosePort()
     m_Socket_fd = -1;
 }
 
+void LinuxCM730::FlushPort()
+{
+	if(m_Socket_fd != -1)
+        tcdrain(m_Socket_fd);
+}
+
 void LinuxCM730::ClearPort()
 {
 	tcflush(m_Socket_fd, TCIFLUSH);

--- a/Linux/include/LinuxCM730.h
+++ b/Linux/include/LinuxCM730.h
@@ -47,6 +47,7 @@ namespace Robot
 		void ClearPort();
 		int WritePort(unsigned char* packet, int numPacket);
 		int ReadPort(unsigned char* packet, int numPacket);
+        void FlushPort();
 
 		void LowPriorityWait();
 		void MidPriorityWait();


### PR DESCRIPTION
I was running into lots of messages failing.  Example dxl_monitor scan
would fail reasonably often, likewise id command or wr command...
Likewise PS3_Demo would fail to startup maybe half the time.

This modificiation is to add a call to tcdrain which waits until the
transmit buffer is empty, before it sets the packet timeout.  This
appears to resolve most/all of the failures I was seeing.

Note: This may not remove all of the latency issues, but at least if
there are delays on sending out the packet the code will wait for this
before trying to get a response.
