### PR TITLE
Fixed gcc constexpr error when trying to build

### DIFF
--- a/Framework/include/AXDXL.h
+++ b/Framework/include/AXDXL.h
@@ -16,10 +16,10 @@ namespace Robot
             static const int MIN_VALUE = 0;
             static const int CENTER_VALUE = 512;
             static const int MAX_VALUE = 1023;
-            static const double MIN_ANGLE = -150.0; // degree
-            static const double MAX_ANGLE = 150.0; // degree
-            static const double RATIO_VALUE2ANGLE = 0.293; // 300 / 1024
-            static const double RATIO_ANGLE2VALUE = 3.413; // 1024 / 300
+            static constexpr double MIN_ANGLE = -150.0; // degree
+            static constexpr double MAX_ANGLE = 150.0; // degree
+            static constexpr double RATIO_VALUE2ANGLE = 0.293; // 300 / 1024
+            static constexpr double RATIO_ANGLE2VALUE = 3.413; // 1024 / 300
 
             static const int PARAM_BYTES = 5;
 

--- a/Framework/include/Camera.h
+++ b/Framework/include/Camera.h
@@ -14,8 +14,8 @@ namespace Robot
 	class Camera
 	{
 		public:
-			static const double VIEW_V_ANGLE = 32.0; //degree
-			static const double VIEW_H_ANGLE = 45.0; //degree
+			static constexpr double VIEW_V_ANGLE = 33.0; //degree
+			static constexpr double VIEW_H_ANGLE = 45.0; //degree
 
 			static const int WIDTH  = 320;
 			static const int HEIGHT = 240;

--- a/Framework/include/Kinematics.h
+++ b/Framework/include/Kinematics.h
@@ -22,13 +22,13 @@ namespace Robot
 		protected:
 
 		public:
-			static const double CAMERA_DISTANCE = 50.00; //mm
-			static const double EYE_TILT_OFFSET_ANGLE = 10.0; //degree
-			static const double LEG_SIDE_OFFSET = 39.0; //mm
-			static const double THIGH_LENGTH = 77.00; //mm
-			static const double CALF_LENGTH = 73.00; //mm
-			static const double ANKLE_LENGTH = 31.6; //mm
-			static const double LEG_LENGTH = 181.6; //mm (THIGH_LENGTH + CALF_LENGTH + ANKLE_LENGTH)
+			static constexpr double CAMERA_DISTANCE = 50.00; //mm
+			static constexpr double EYE_TILT_OFFSET_ANGLE = 10.0; //degree
+			static constexpr double LEG_SIDE_OFFSET = 39.0; //mm
+			static constexpr double THIGH_LENGTH = 77.00; //mm
+			static constexpr double CALF_LENGTH = 73.00; //mm
+			static constexpr double ANKLE_LENGTH = 31.6; //mm
+			static constexpr double LEG_LENGTH = 181.6; //mm (THIGH_LENGTH + CALF_LENGTH + ANKLE_LENGTH)
 
 			~Kinematics();
 


### PR DESCRIPTION
```console
$ make clean all
rm -f ./cmd_process.o ./main.o rme
make -C ../../build
make[1]: Entering directory '/home/pdxjohnny/HROS1-Framework/Linux/build'
mkdir -p ../lib/
ar cr ../lib/darwin.a ../../Framework/src/ArbotixPro.o ../../Framework/src/math/Matrix.o ../../Framework/src/math/Plane.o ../../Framework/src/math/Point.o ../../Framework/src/math/Vector.o ../../Framework/src/math/QuadraticStateTransform.o ../../Framework/src/math/MotionState.o ../../Framework/src/motion/JointData.o ../../Framework/src/motion/Kinematics.o ../../Framework/src/motion/MotionManager.o ../../Framework/src/motion/MotionStatus.o ../../Framework/src/motion/AngleEstimator.o ../../Framework/src/motion/modules/Action.o ../../Framework/src/motion/modules/Head.o ../../Framework/src/motion/modules/Walking.o ../../Framework/src/vision/BallFollower.o ../../Framework/src/vision/PS3BallFollower.o ../../Framework/src/vision/LineFollower.o ../../Framework/src/vision/RobotFollower.o ../../Framework/src/vision/ConnectRegions.o ../../Framework/src/vision/RadonTransform.o ../../Framework/src/vision/BallTracker.o ../../Framework/src/vision/ColorFinder.o ../../Framework/src/vision/Image.o ../../Framework/src/vision/ImgProcess.o ../../Framework/src/minIni/minIni.o ../../Framework/src/controller/PS3Controller.o streamer/httpd.o streamer/jpeg_utils.o streamer/mjpg_streamer.o LinuxActionScript.o LinuxCamera.o LinuxArbotixPro.o LinuxMotionTimer.o LinuxNetwork.o
make[1]: Leaving directory '/home/pdxjohnny/HROS1-Framework/Linux/build'
g++ -fPIC -O2 -DLINUX -g -Wall -fmessage-length=0 -I../../include -I../../../Framework/include   -c -o cmd_process.o cmd_process.cpp
In file included from ../../../Framework/include/ArbotixPro.h:11:0,
                 from ../../../Framework/include/DARwIn.h:11,
                 from ../../include/LinuxDARwIn.h:11,
                 from cmd_process.h:5,
                 from cmd_process.cpp:8:
../../../Framework/include/AXDXL.h:19:33: error: ‘constexpr’ needed for in-class initialization of static data member ‘const double Robot::AXDXL::MIN_ANGLE’ of non-integral type [-fpermissive]
             static const double MIN_ANGLE = -150.0; // degree
                                 ^~~~~~~~~
../../../Framework/include/AXDXL.h:20:33: error: ‘constexpr’ needed for in-class initialization of static data member ‘const double Robot::AXDXL::MAX_ANGLE’ of non-integral type [-fpermissive]
             static const double MAX_ANGLE = 150.0; // degree
                                 ^~~~~~~~~
../../../Framework/include/AXDXL.h:21:33: error: ‘constexpr’ needed for in-class initialization of static data member ‘const double Robot::AXDXL::RATIO_VALUE2ANGLE’ of non-integral type [-fpermissive]
             static const double RATIO_VALUE2ANGLE = 0.293; // 300 / 1024
                                 ^~~~~~~~~~~~~~~~~
../../../Framework/include/AXDXL.h:22:33: error: ‘constexpr’ needed for in-class initialization of static data member ‘const double Robot::AXDXL::RATIO_ANGLE2VALUE’ of non-integral type [-fpermissive]
             static const double RATIO_ANGLE2VALUE = 3.413; // 1024 / 300
                                 ^~~~~~~~~~~~~~~~~
In file included from ../../../Framework/include/DARwIn.h:25:0,
                 from ../../include/LinuxDARwIn.h:11,
                 from cmd_process.h:5,
                 from cmd_process.cpp:8:
../../../Framework/include/Camera.h:17:24: error: ‘constexpr’ needed for in-class initialization of static data member ‘const double Robot::Camera::VIEW_V_ANGLE’ of non-integral type [-fpermissive]
    static const double VIEW_V_ANGLE = 32.0; //degree
                        ^~~~~~~~~~~~
../../../Framework/include/Camera.h:18:24: error: ‘constexpr’ needed for in-class initialization of static data member ‘const double Robot::Camera::VIEW_H_ANGLE’ of non-integral type [-fpermissive]
    static const double VIEW_H_ANGLE = 45.0; //degree
                        ^~~~~~~~~~~~
make: *** [<builtin>: cmd_process.o] Error 1
```

Signed-off-by: John Andersen <johnandersenpdx@gmail.com>